### PR TITLE
update the travis SRC_DIR for teletype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - LIBAVR32_DIR=libavr32
     - env:
         - REPO=monome/teletype
-        - SRC_DIR=src
+        - SRC_DIR=module
         - LIBAVR32_DIR=libavr32
     - env:
         - REPO=monome/whitewhale


### PR DESCRIPTION
Fixes the travis build to use the correct directory now that the module code has been moved out of src.