### PR TITLE
fixed usb midi packet parsing

### DIFF
--- a/src/notes.c
+++ b/src/notes.c
@@ -7,7 +7,7 @@
 // the pool is structured as a linked list ordered from most recent to least
 // recent notes.
 
-#define POOL_SIZE 12
+#define POOL_SIZE 24
 
 struct pool_element {
   held_note_t note;

--- a/src/usb/midi/midi.c
+++ b/src/usb/midi/midi.c
@@ -1,13 +1,14 @@
 /*
   midi.c
-  aleph-avr32
+  libavr32
 
   usb MIDI functions.
 */
 
 // asf
 #include "print_funcs.h"
-// aleph-avr32
+
+// libavr32
 #include "conf_usb_host.h"
 #include "events.h"
 #include "events.h"
@@ -22,160 +23,100 @@
 // the buffer will start filling up if events come in faster than the polling rate
 // the more full the buffer, the longer we'll spend in the usb read ISR parsing it...
 // so it is a tradeoff.
-#define MIDI_RX_BUF_SIZE 64
+#define MIDI_RX_EVENT_BUF_SIZE 16
+#define MIDI_TX_EVENT_BUF_SIZE 16
 
-#define MIDI_TX_BUF_SIZE 64
 
-// max packet length.
-// a packet contains status and data byte for a typical midi message.
-// sysex and other long/weird messages can be ignored for now.
-// 4 bytes will fit in event data.
-// longer than that we will have to use a global pointer to the rx buf or some shit.
-#define MIDI_MAX_PACKET_SIZE 	4
-#define MIDI_MAX_PACKET_SIZE_1 	3
+//------------------------------
+//----- types
 
-//------------------------------------
-//------ extern variables
-u8 midiConnect = 0;
+// usb midi event type
+// See http://www.usb.org/developers/docs/devclass_docs/midi10.pdf
+// Section 4 (page 16)
+typedef union {
+  struct { u8 header; u8 msg[3]; };
+  u32 raw;
+} usb_midi_event_t;
 
 //------------------------------------
 //------ static variables
 // 
+
 // buffers must be word aligned per docs on uhd_ep_run()
-COMPILER_WORD_ALIGNED static u8 rxBuf[MIDI_RX_BUF_SIZE];
+COMPILER_WORD_ALIGNED static usb_midi_event_t rxBuf[MIDI_RX_EVENT_BUF_SIZE];
+static volatile bool rxBusy = false;
 static u32 rxBytes = 0;
-static volatile u8 rxBusy = 0;
-static volatile u8 txBusy = 0;
 
 // try using an output buffer and adding the extra nib we saw on input ... 
-COMPILER_WORD_ALIGNED static u8 txBuf[MIDI_TX_BUF_SIZE];
+COMPILER_WORD_ALIGNED static usb_midi_event_t txBuf[MIDI_TX_EVENT_BUF_SIZE];
+static volatile bool txBusy = false;
+static volatile u8 txGetIdx = 0;
+static volatile u8 txPutIdx = 0;
 
 // current packet data
-//union { u8 buf[MIDI_MAX_PACKET_SIZE]; s32 data; } packet;
-// address of last packet byte
-//u8* packetEnd = &(packet.buf[3]);
-// event
 static event_t ev = { .type = kEventMidiPacket, .data = 0x00000000 };
-static union { u8 buf[4]; u32 data; s32 sdata; } packet;
-// pointers into the event data (hacky)
-//static u8* const packetStart = (u8*)&(ev.data);
-//static u8* const packetEnd = (u8*)&(ev.data) + 3;
-static u8* const packetStart = &(packet.buf[0]);
-static u8* const packetEnd = &(packet.buf[3]);
 
 //------------------------------------
 //----- static functions
+
 // parse the buffer and spawn appropriate events
-static void midi_parse(void) {
-  // current byte data
-  u8 b; 
-  // skip the first byte ( CABLE | COM )
-  u8* src = rxBuf + 1;
-  // temp pointer to packet
-  u8* dst = packetStart;
-  // flag if we have received a status byte
-  u8 stat = 0;
-  // bytes processed
-  u8 nb = 0;
+static void midi_parse_event(void) {
+  int i;
+  int eventCount = rxBytes >> 2; // assume we receive full events, partials are dropped
 
-  // clear packet data
-  //  ev.data = 0x00000000;
-  packet.data = 0x00000000;
+  union { u32 data; s32 sdata; } buf;
 
-  //  print_dbg("\r\n ");
+  usb_midi_event_t* rxEvent = &(rxBuf[0]);
 
-  while(nb < rxBytes) {
-    b = *src;
-    ++src;
-    ++nb;
-    if(b & 0x80) {
-      // this is a status byte
-      dst = packetStart;
-      //      print_dbg("\r\n parsed status byte. packet contents: 0x");
-      //      print_dbg_hex(packet.data);
-      //      print_dbg(" | SB ( ");
-      //      print_dbg_hex(packet.data);
-      //      print_dbg(" )");
-
-      if(stat) {
-        // if we already had a status byte, send the previous packet
-	      ev.data = packet.sdata;
-		    // print_dbg("\r\n sending MIDI packet: ");
-		    // print_dbg_hex(packet.data);
-	      event_post(&ev);
-      }
-      *dst = b;
-      stat = 1;  
-    } else {
-      // this is a data byte or whatever
-      ++dst;
-      if(dst > packetEnd) {
-        // exceeded packet size (sysex?), so give up on this packet
-        stat = 0;
-      } else {
-        *dst = b;
-      }
-    }
-  }
-  // at the end of a buffer, send a packet if we have a pending status
-  if(stat) {
-      //  print_dbg("\r\n sending MIDI packet: ");
-    ev.data = packet.sdata;
-      //  print_dbg_hex(packet.data);
+  for (i = 0; i < eventCount; i++) {
+    buf.data = (rxEvent->raw) << 8;
+    ev.data = buf.sdata;
     event_post(&ev);
+
+    ++rxEvent;
   }
 }
 
 // callback for the non-blocking asynchronous read.
-static void midi_rx_done( usb_add_t add,
-			  usb_ep_t ep,
-			  uhd_trans_status_t stat,
-			  iram_size_t nb) {
-  // int i;
-  rxBusy = 0;
-  if(nb > 0) {
-    // print_dbg("\r\n midi rx; uhd status: 0x");
-    // print_dbg_hex((u32)stat);
-    // print_dbg(" ; nb: ");
-    // print_dbg_ulong(nb);
-    // print_dbg(" ; data: ");
-    // for(i=0; i<nb; i++) {
-    //   print_dbg_char_hex(rxBuf[i]);
-    //   print_dbg(" ");
-    // }
+static void midi_rx_done(usb_add_t add,
+                         usb_ep_t ep,
+                         uhd_trans_status_t stat,
+                         iram_size_t nb) {
+  if (nb > 0) {
     if (stat == UHD_TRANS_NOERROR) {
-      // ignoring 1st byte, virtual cable select
-      rxBytes = nb - 1;
-      midi_parse();
+      rxBytes = nb;
+      midi_parse_event();
     }
-  } 
+  }
+
+  rxBusy = false;
 }
 
-static void midi_tx_done( usb_add_t add,
-			  usb_ep_t ep,
-			  uhd_trans_status_t stat,
-			  iram_size_t nb) {
+// callback for the non-blocking asynchronous write.
+static void midi_tx_done(usb_add_t add,
+                         usb_ep_t ep,
+                         uhd_trans_status_t stat,
+                         iram_size_t nb) {
+  if (stat != UHD_TRANS_NOERROR) {
+    print_dbg("\r\n midi tx error (in callback). status: 0x");
+    print_dbg_hex((u32)stat);
+  }
 
   txBusy = false;
-  print_dbg("\r\n midi tx transfer callback. status: 0x"); 
-  print_dbg_hex((u32)stat); 
-  if (stat != UHD_TRANS_NOERROR) {
-    print_dbg("\r\n midi tx error (in callback)");
-    return;
-  }
 }
+
 
 //-----------------------------------------
 //----- extern functions
+
 // read and spawn events (non-blocking)
 extern void midi_read(void) {
-  if (rxBusy == 0) {
+  if (rxBusy == false) {
     rxBytes = 0;
-    rxBusy = 1;
-    if (!uhi_midi_in_run((u8*)rxBuf,
-		        MIDI_RX_BUF_SIZE, &midi_rx_done)) {
+    rxBusy = true;
+    if (!uhi_midi_in_run((u8*)rxBuf, sizeof rxBuf, &midi_rx_done)) {
       // hm, every uhd enpoint run always returns error...
-      // ...becasue most of the time a rx job is already running, by only
+      // ...because most of the time a rx job is already running, by only
       // running the endpoint read after midi_rx_done has set rxBusy to false
       // the errors here stop.
       print_dbg("\r\n midi rx endpoint error");
@@ -185,52 +126,115 @@ extern void midi_read(void) {
 }
 
 // write to MIDI device
-extern void midi_write(const u8* data, u32 bytes) {
-  u8* pbuf = &(txBuf[1]);
-  int i;
- 
-  // copy to buffer 
-  for(i=0; i<bytes; ++i){
-    *pbuf++ = data[i];
+extern bool midi_write(const u8* data, u32 bytes) {
+  // NB: this function is not currently used across the module code
+  // base therefore the precise nature of the incoming buffer layout
+  // is not well defined.
+  //
+  // here it is assumed that the midi data is packed (not padded to 3
+  // bytes) but that running status is not used...
+  //
+  // TODO: testing...
+	//
+	// FIXME: if txBuf is not large enough to hold all of data the extra
+	// msgs in data are dropped
+
+  u8 events = 1;
+  usb_midi_event_t* tx = &(txBuf[0]);
+  const usb_midi_event_t* txEnd = &(txBuf[MIDI_RX_EVENT_BUF_SIZE]);
+
+  u8* d = (u8*)data;
+  const u8* dEnd = data + bytes;
+
+  u8 status, com, ch;
+
+  if (txBusy == false) {
+    print_dbg("\r\n midi_write: no buffers available");
+    return false;
   }
 
-  // high nib of 1st byte = virtual cable, leaving 0
-  // low nib = 4b com code, duplicated from status byte
-  txBuf[0] = (u8) (data[0] >> 4); 
-  /// try cable idx 1
-  txBuf[0] |= 0x10;
- 
-  print_dbg("\r\n midi tx; data: ");
-  for(i=0; i<(bytes+1); i++) {
-    print_dbg_char_hex(txBuf[i]);
-    print_dbg(" ");
+  while (tx < txEnd && d < dEnd) {
+    // clean the tx buffer
+    tx->raw = 0x00000000;
+
+    // grab the status byte
+    status = *d; d++;
+    com = status >> 4;
+    ch = status & 0x0f;
+
+    if (com < 0x8) {
+      // bad status byte, just bail
+      print_dbg("\r\n midi_write: bad status in data, skipping write");
+      return false;
+    }
+
+    // format usb midi header, high nib of 1st byte = virtual cable
+    // low nib = 4b com code, duplicated from status byte
+    tx->header = 0x10 | com;
+    tx->msg[0] = status;
+
+    // based on message type copy the correct number of bytes into the
+    // events
+    if (com < 0xf) {
+      // channel mode message
+      tx->msg[1] = *d; d++;
+      if (com == 0xc || com == 0xd) {
+        // program change, aftertouch => 1 byte, nothing more
+      }
+      else {
+        tx->msg[2] = *d; d++;
+      }
+    }
+    else if (ch < 0x8) {
+      // system common message
+      if (ch == 0x0 || ch == 0x7) {
+        // sysex start, end
+        print_dbg("\r\n midi_write: sysex not supported, skipping write");
+        return false;
+      }
+      else if (ch == 0x2) {
+        // song position pointer
+        tx->msg[1] = *d; d++;
+        tx->msg[2] = *d; d++;
+      }
+      else if (ch == 0x1 || ch == 0x3) {
+        // midi time code quarter frame, song select
+        tx->msg[1] = *d; d++;
+      }
+      else {
+        // undefined or tune request
+        // ...nothing to do
+      }
+    }
+    else {
+      // system realtime message
+      // ...status byte only, nothing to do
+    }
+
+    tx++; events++;
   }
 
-
-  print_dbg("\r\n midi_write...");
   txBusy = true;
-  if (!uhi_midi_out_run(txBuf, bytes+1, &midi_tx_done)) {
+
+  if (!uhi_midi_out_run((uint8_t*)txBuf, events * sizeof(usb_midi_event_t), &midi_tx_done)) {
     // hm, every uhd enpoint run always returns unspecified error...
-      //  print_dbg("\r\n midi tx endpoint error");
+    //  print_dbg("\r\n midi tx endpoint error");
   }
-  return;
+
+  return true;
 }
 
 // MIDI device was plugged or unplugged
 extern void midi_change(uhc_device_t* dev, u8 plug) {
   event_t e;
-  if(plug) { 
+
+  if (plug) { 
     e.type = kEventMidiConnect; 
   } else {
     e.type = kEventMidiDisconnect;
   }
+
   // posting an event so the main loop can respond
   event_post(&e); 
-  //  midiConnect = plug;
 }
 
-// main-loop setup routine for new device connection
-///  do we need to make any control requests?
-////
-/* extern void midi_setup(void) { */
-/* } */

--- a/src/usb/midi/midi.h
+++ b/src/usb/midi/midi.h
@@ -4,22 +4,17 @@
 #include "types.h"
 #include "uhc.h"
 
-extern u8 midiConnect;
+
+
 
 // read and spawn events (non-blocking)
 extern void midi_read(void);
 
 // write to MIDI device
-extern void midi_write(const u8* data, u32 bytes);
+extern bool midi_write(const u8* data, u32 bytes);
 
 // MIDI device was plugged or unplugged
 extern void midi_change(uhc_device_t* dev, u8 plug);
-
-// main-loop setup routine for new device connection.
-// this would be the place to perform any queries which require interrupts,
-// and whose completion is necessary before polling.
-// extern void midi_setup(void);
-
 
 
 #endif


### PR DESCRIPTION
these changes address the earthsea lockups when in usb midi mode

(_once merged earthsea can be updated to the new version of libavr32 and rebuilt_)

note handling:
- increased held note buffer from 12 to 24

midi parsing:
- introduced ```usb_midi_event_t```
- increased rx buffer size
- removed dead, commented out code
- ensure ```rxBusy``` set to true after events are posted
- new ```midi_write```, outputting multiple midi messages supported

testing of ```midi_write``` and refinement still needed (but no module currently uses ```midi_write```, only ```midi_read```)