### PR TITLE
add missing "types.h" header to "adc.h"

### DIFF
--- a/src/adc.h
+++ b/src/adc.h
@@ -2,6 +2,7 @@
 #define _ADC_H_
 
 #include "compiler.h"
+#include "types.h"
 
 // setup ad7923
 extern void init_adc(void);

--- a/src/usb/ftdi/ftdi.h
+++ b/src/usb/ftdi/ftdi.h
@@ -1,9 +1,9 @@
 /* ftdi.h
-   
+
    ftdi driver for monome aleph
  */
 
-#ifndef _ALEPH_FTD_H_
+#ifndef _ALEPH_FTDI_H_
 #define _ALEPH_FTDI_H_
 
 #include "types.h"


### PR DESCRIPTION
I'd been playing around with the whitewhale firmware, after a `clang-format`, the headers got rearranged, moving `include "types.h"`  to after `include "adc.h"` which broke compilation.