### PR TITLE
Fixed error in debug messages 

### DIFF
--- a/src/monome.c
+++ b/src/monome.c
@@ -568,9 +568,9 @@ static u8 setup_mext(void) {
   // print_dbg_ulong(rxBytes);
 
   if(rxBytes != 6 ){
-    print_dbg("\r\n got unexpected byte count in response to mext setup request;\r\n");
-    print_dbg_ulong(*prx);
-    
+    print_dbg("\r\n got unexpected byte count in response to mext setup request; \r\n");
+    prx = ftdi_rx_buf();
+
     for(;rxBytes != 0; rxBytes--) {
       print_dbg_ulong(*(++prx));
       print_dbg(" ");


### PR DESCRIPTION
[mext]
When the query response is not the expected 6 bytes (shouldn't it be three bytes anyways?) the response data is dumped to the log uart. A) for a messge with N bytes, N+1 bytes were dumped to the uart B) the dumped data was from a random memory location due to prx pointer being uninitialized.
