### PR TITLE
Teletype 2.0 changes

### DIFF
--- a/conf/conf_usb_host.h
+++ b/conf/conf_usb_host.h
@@ -71,7 +71,7 @@
 // midi functions
 // #define UHI_MIDI_CHANGE(dev, b_plug) midi_change(dev, b_plug)
 
-#define UHI_MSC_CHANGE(dev,b_plug)
+#define UHI_MSC_CHANGE(dev,b_plug) msc_change(dev, b_plug)
 
 
 #include "uhi_ftdi.h"
@@ -80,5 +80,6 @@
 //#include "ui.h"
 #include "usb.h"
 #include "uhi_msc.h"
+#include "msc.h"
 
 #endif // _CONF_USB_HOST_H_

--- a/src/arp.c
+++ b/src/arp.c
@@ -133,14 +133,16 @@ void arp_seq_init(arp_seq_t* s) {
 
 bool arp_seq_set_state(arp_seq_t *s, arp_seq_state state) {
 	bool result = false;
-	
-	cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
+
+  // disable timer interrupts
+  timers_pause();
 
 	s->state = state;
 	result = true;
 
-	cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
-	
+  // enable timer interrupts
+  timers_resume();
+
 	return result;
 }
 

--- a/src/dac.c
+++ b/src/dac.c
@@ -106,9 +106,7 @@ uint16_t dac_get_off(uint8_t n) {
 
 void dac_update_now(void) {
 	// update the dacs now
-	//cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
 	dac_timer_update();
-	//cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
 }
 
 void dac_timer_update(void) {

--- a/src/events.c
+++ b/src/events.c
@@ -91,9 +91,12 @@ u8 event_post( event_t *e ) {
   } else {
     // idx wrapped, so queue is full, restore idx
     putIdx = saveIndex;
-    print_dbg("\r\n event queue full!");
   } 
 
   cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
+
+  if (!status)
+    print_dbg("\r\n event queue full!");
+
   return status;
 }

--- a/src/events.c
+++ b/src/events.c
@@ -52,8 +52,9 @@
 // Returns non-zero if an event was available
 u8 event_next( event_t *e ) {
   u8 status;
-  cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
-  
+
+  irqflags_t flags = cpu_irq_save();
+
   // if pointers are equal, the queue is empty... don't allow idx's to wrap!
   if ( getIdx != putIdx ) {
     INCR_EVENT_INDEX( getIdx );
@@ -66,7 +67,8 @@ u8 event_next( event_t *e ) {
     status = false;
   }
 
-  cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
+  cpu_irq_restore(flags);
+
   return status;
 }
 
@@ -79,8 +81,8 @@ u8 event_post( event_t *e ) {
    // print_dbg("\r\n posting event, type: ");
    // print_dbg_ulong(e->type);
 
-  cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
-  
+  irqflags_t flags = cpu_irq_save();
+
   // increment write idx, posbily wrapping
   saveIndex = putIdx;
   INCR_EVENT_INDEX( putIdx );
@@ -93,7 +95,7 @@ u8 event_post( event_t *e ) {
     putIdx = saveIndex;
   } 
 
-  cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
+  cpu_irq_restore(flags);
 
   if (!status)
     print_dbg("\r\n event queue full!");

--- a/src/events.c
+++ b/src/events.c
@@ -12,9 +12,11 @@
 #include "conf_tc_irq.h"
 #include "events.h"
 
+ static void handler_Ignore(s32 data) { }
 
 // global array of pointers to handlers
- void (*app_event_handlers[kNumEventTypes])(s32 data);
+// initialise all it's entries to handler_Ignore
+ void (*app_event_handlers[kNumEventTypes])(s32 data) = { handler_Ignore };
 
 
 /// NOTE: if we are ever over-filling the event queue, we have problems.

--- a/src/events.h
+++ b/src/events.h
@@ -30,6 +30,9 @@ typedef enum {
   kEventHidDisconnect,
   kEventHidPacket,
   kEventHidTimer,
+  // MSC
+  kEventMscConnect,
+  kEventMscDisconnect,
   
   kEventScreenRefresh,
   // Trigger EVENT (8 digital inputs)

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -19,7 +19,7 @@ static twi_package_t packet;
 volatile process_ii_t process_ii;
 
 
-void i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t length) {
+int i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t length) {
   int status;
 
   packet.chip = addr;
@@ -29,18 +29,14 @@ void i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t length) {
   // How many bytes do we want to write
   packet.length = length;
 
-  // print_dbg("\r\nii_tx ");
-  // for(int i =0;i< length;i++) {
-  //   print_dbg_ulong(data[i]);
-  //   print_dbg(" ");
-  // }
-
   // perform a write access
   status = twi_master_write(TWI, &packet);
+
+  return status;
 }
 
 
-void i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l) {
+int i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l) {
   int status;
 
   packet.chip = addr;
@@ -52,16 +48,12 @@ void i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l) {
 
   status = twi_master_read(TWI, &packet);
 
-  //   print_dbg("\r\nii_rx ");
-  // for(int i =0;i<l;i++) {
-  //   print_dbg_ulong(data[i]);
-  //   print_dbg(" ");
-  // }
+  return status;
 }
 
 
 
-void twi_slave_rx( U8 u8_value )
+void twi_slave_rx(uint8_t u8_value)
 {
   if (rx_pos[rx_buffer_index] < I2C_RX_BUF_SIZE) {
     rx_buffer[rx_buffer_index][rx_pos[rx_buffer_index]] = u8_value;
@@ -69,7 +61,7 @@ void twi_slave_rx( U8 u8_value )
   }
 }
 
-void twi_slave_stop( void )
+void twi_slave_stop(void)
 {
   uint8_t index = rx_buffer_index;
   // rx_buffer_index must be incremented before process_ii is called
@@ -92,7 +84,7 @@ extern void ii_tx_queue(uint8_t data) {
     print_dbg("\r\nii queue overrun");
 }
 
-uint8_t twi_slave_tx( void )
+uint8_t twi_slave_tx(void)
 {
    // print_dbg("\r\nii_tx ");
    if(tx_pos_write == tx_pos_read)

--- a/src/i2c.h
+++ b/src/i2c.h
@@ -1,6 +1,8 @@
 #ifndef _I2C_H_
 #define _I2C_H_
 
+#include <stdint.h>
+
 // PPP framing
 #define STX 12
 #define ETX 13
@@ -9,12 +11,12 @@
 #define I2C_TX_BUF_SIZE 8
 #define I2C_RX_BUF_SIZE 8
 
-extern void i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t l);
-extern void i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l);
+extern int i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t l);
+extern int i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l);
 
-extern void twi_slave_rx( U8 u8_value );
-extern U8 twi_slave_tx( void );
-extern void twi_slave_stop( void );
+extern void twi_slave_rx(uint8_t u8_value);
+extern uint8_t twi_slave_tx(void);
+extern void twi_slave_stop(void);
 
 extern void ii_tx_queue(uint8_t);
 

--- a/src/init_teletype.c
+++ b/src/init_teletype.c
@@ -77,10 +77,10 @@ __attribute__((__interrupt__))
 static void irq_port0_line0(void) {
   for(int i=0;i<8;i++) {
     if(gpio_get_pin_interrupt_flag(i)) {
-      gpio_clear_pin_interrupt_flag(i);
       // print_dbg("\r\n # A00");
       event_t e = { .type = kEventTrigger, .data = i };
       event_post(&e);
+      gpio_clear_pin_interrupt_flag(i);
     }
   }
 }
@@ -89,10 +89,10 @@ static void irq_port0_line0(void) {
 __attribute__((__interrupt__))
 static void irq_port0_line1(void) {
     if(gpio_get_pin_interrupt_flag(NMI)) {
-      gpio_clear_pin_interrupt_flag(NMI);
       // print_dbg("\r\n ### NMI ### ");
       event_t e = { .type = kEventFront, .data = gpio_get_pin_value(NMI) };
       event_post(&e);
+      gpio_clear_pin_interrupt_flag(NMI);
     }
 }
 

--- a/src/init_teletype.c
+++ b/src/init_teletype.c
@@ -22,8 +22,8 @@
 //------------------------
 //----- variables
 // timer tick counter
-volatile u64 tcTicks = 0;
-volatile u8 tcOverflow = 0;
+static volatile u64 tcTicks = 0;
+static volatile u8 tcOverflow = 0;
 static const u64 tcMax = (U64)0x7fffffff;
 static const u64 tcMaxInv = (u64)0x10000000;
 

--- a/src/init_teletype.c
+++ b/src/init_teletype.c
@@ -79,9 +79,7 @@ static void irq_port0_line0(void) {
     if(gpio_get_pin_interrupt_flag(i)) {
       gpio_clear_pin_interrupt_flag(i);
       // print_dbg("\r\n # A00");
-      static event_t e;
-      e.type = kEventTrigger;
-      e.data = i;
+      event_t e = { .type = kEventTrigger, .data = i };
       event_post(&e);
     }
   }
@@ -93,9 +91,7 @@ static void irq_port0_line1(void) {
     if(gpio_get_pin_interrupt_flag(NMI)) {
       gpio_clear_pin_interrupt_flag(NMI);
       // print_dbg("\r\n ### NMI ### ");
-      static event_t e;
-      e.type = kEventFront;
-      e.data = gpio_get_pin_value(NMI);
+      event_t e = { .type = kEventFront, .data = gpio_get_pin_value(NMI) };
       event_post(&e);
     }
 }

--- a/src/init_teletype.h
+++ b/src/init_teletype.h
@@ -3,10 +3,6 @@
 
 #include "types.h"
 
-// global count of uptime, and overflow flag.
-volatile u64 tcTicks;
-volatile u8 tcOverflow;
-
 extern void register_interrupts(void);
 extern void init_gpio(void);
 extern void init_spi(void);

--- a/src/kbd.c
+++ b/src/kbd.c
@@ -3,6 +3,7 @@
 
 #include "kbd.h"
 
+static s8 old_frame[8];
 
 bool frame_compare(u8 data) {
 	u8 i;

--- a/src/kbd.h
+++ b/src/kbd.h
@@ -49,8 +49,6 @@
 /**/
 
 
-s8 old_frame[8];
-
 extern u8 hid_to_ascii_raw(u8 data);
 extern u8 hid_to_ascii(u8 data, u8 mod);
 extern bool frame_compare(u8 data);

--- a/src/timers.c
+++ b/src/timers.c
@@ -142,6 +142,14 @@ u8 timer_remove( softTimer_t* t) {
    num = 0;
 }
 
+void timers_resume( void ) {
+    cpu_irq_enable_level(APP_TC_IRQ_PRIORITY);
+}
+
+void timers_pause( void ) {
+    cpu_irq_disable_level(APP_TC_IRQ_PRIORITY);
+}
+
 // process the timer list, presumably from TC interrupt
 void process_timers( void ) {
   u32 i;

--- a/src/timers.h
+++ b/src/timers.h
@@ -35,6 +35,8 @@ u8 timer_add( softTimer_t* timer, u32 ticks, timer_callback_t callback, void* ca
 // find remove a timer from the processing list
 // return 1 if removed, 0 if not found
 u8 timer_remove( softTimer_t* timer );
+void timers_resume( void );
+void timers_pause( void );
 // process the timer list; call this on each tick.
 void process_timers( void );
 

--- a/src/timers.h
+++ b/src/timers.h
@@ -35,8 +35,10 @@ u8 timer_add( softTimer_t* timer, u32 ticks, timer_callback_t callback, void* ca
 // find remove a timer from the processing list
 // return 1 if removed, 0 if not found
 u8 timer_remove( softTimer_t* timer );
-void timers_resume( void );
+// pause the timer, returning it's state before being paused
 void timers_pause( void );
+// resume the timer
+void timers_resume( void );
 // process the timer list; call this on each tick.
 void process_timers( void );
 

--- a/src/usb/msc/msc.c
+++ b/src/usb/msc/msc.c
@@ -1,0 +1,21 @@
+#include "msc.h"
+
+// std
+#include <stdint.h>
+
+// asf
+#include "uhc.h"
+
+// libavr32
+#include "events.h"
+
+void msc_change(uhc_device_t* dev, uint8_t plug) {
+    if (plug) {
+        event_t e = {.type = kEventMscConnect, .data = 0};
+        event_post(&e);
+    }
+    else {
+        event_t e = {.type = kEventMscDisconnect, .data = 0};
+        event_post(&e);
+    }
+}

--- a/src/usb/msc/msc.h
+++ b/src/usb/msc/msc.h
@@ -1,0 +1,10 @@
+#ifndef _USB_MSC_H_
+#define _USB_MSC_H_
+
+#include <stdint.h>
+
+#include "uhc.h"
+
+void msc_change(uhc_device_t* dev, uint8_t plug);
+
+#endif

--- a/test/include/conf_tc_irq.h
+++ b/test/include/conf_tc_irq.h
@@ -2,8 +2,7 @@
 #define __CONF_TC_IRQ_H__
 
 // dummy; just get rid of them for now
-#define cpu_irq_disable_level(x)
-#define cpu_irq_enable_level(x)
-
+#define timers_pause()
+#define timers_resume()
 
 #endif // __CONF_TC_IRQ_H__


### PR DESCRIPTION
Mainly just some small additions and changes.

1. Initialise `app_event_handlers` to be an array of `handler_Ignore`, which means that unhandled events will not cause crashes

2. Add events and support for USB memory sticks

3. Add timer pause and resume functions

Plus some other smaller tweaks.

---

**Unfortunately this breaks all the modules**, due to none of them compiling `msc.c` or being able to find `msc.h`.

Here are the PRs to fix that:

- Teletype: https://github.com/monome/teletype/pull/73
- Ansible: https://github.com/monome/ansible/pull/24

I'll do the Trilogy modules once this, the Teletype and the Ansible changes are merged.