### PR TITLE
adding KR.CV and ME.CV ops

### DIFF
--- a/src/ii.h
+++ b/src/ii.h
@@ -57,6 +57,7 @@
 #define II_MP_STOP		2
 #define II_MP_SCALE		3
 #define II_MP_PERIOD	4
+#define II_MP_CV		5
 #define II_LV_ADDR		0xAC
 #define II_LV_PRESET	0
 #define II_LV_RESET 	1

--- a/src/ii.h
+++ b/src/ii.h
@@ -50,6 +50,7 @@
 #define II_KR_LOOP_ST	5
 #define II_KR_LOOP_LEN	6
 #define II_KR_RESET		7
+#define II_KR_CV		8
 #define II_MP_ADDR		0xAA
 #define II_MP_PRESET	0
 #define II_MP_RESET 	1


### PR DESCRIPTION
While both Levels and Cycles on Ansible currently have operators to read CV, both of the grid-based sequencers, Kria and Meadowphysics, lack this feature.

This pull request adds the #defines necessary for these ops to be added to the Teletype and Ansible firmware, where I've already implemented the ops and for which I can submit pull requests once this one is merged.