### PR TITLE
protect ftdi setup

### DIFF
--- a/src/monome.c
+++ b/src/monome.c
@@ -75,9 +75,9 @@ refresh_t monome_refresh;
 static monomeDesc mdesc = {
   .protocol = eProtocolNumProtocols, // dummy
   .device = eDeviceNumDevices, // dummy
-  .cols = 0,
-  .rows = 0,
-  .encs = 0,
+  .cols = 16,
+  .rows = 8,
+  .encs = 4,
   .tilt = 0,
 };
 
@@ -222,6 +222,12 @@ u8 check_monome_device_desc(char* mstr, char* pstr, char* sstr) {
   buf[i] = 0;
   /* print_dbg("\r\n serial string: "); */
   /* print_dbg(buf); */
+  mdesc.protocol = eProtocolNumProtocols;
+  mdesc.device = eDeviceNumDevices;
+  mdesc.cols = 16;
+  mdesc.rows = 8;
+  mdesc.encs = 4;
+  mdesc.tilt = 0;
   if(matchMan == 0) {
     // didn't match the manufacturer string, but check the serial for DIYs
     if( strncmp(buf, "a40h", 4) == 0) {

--- a/src/usb/ftdi/ftdi.c
+++ b/src/usb/ftdi/ftdi.c
@@ -111,7 +111,7 @@ void ftdi_change(uhc_device_t* dev, u8 plug) {
 }
 
 // setup new device connection
-void ftdi_setup(void) {
+u8 ftdi_setup(void) {
   char * manstr;
   char * prodstr;
   char * serstr;
@@ -122,13 +122,13 @@ void ftdi_setup(void) {
   ftdiConnect = 1;
 
   // get string data...
-  ftdi_get_strings(&manstr, &prodstr, &serstr);
+  if (!ftdi_get_strings(&manstr, &prodstr, &serstr)) return 0;
   // print the strings
   // print_unicode_string(manstr, FTDI_STRING_MAX_LEN);
   //  print_unicode_string(prodstr, FTDI_STRING_MAX_LEN);
   //  print_unicode_string(serstr, FTDI_STRING_MAX_LEN);
   //// query if this is a monome device
-  check_monome_device_desc(manstr, prodstr, serstr);
+  return check_monome_device_desc(manstr, prodstr, serstr);
   //// TODO: other protocols??
 }
 

--- a/src/usb/ftdi/ftdi.h
+++ b/src/usb/ftdi/ftdi.h
@@ -34,7 +34,7 @@ extern void ftdi_write(u8* data, u32 bytes);
 // FTDI device was plugged or unplugged
 extern void ftdi_change(uhc_device_t* dev, u8 plug);
 // main-loop setup routine for new device connection
-extern void ftdi_setup(void);
+extern u8 ftdi_setup(void);
 
 //-- getters
 

--- a/src/usb/ftdi/uhi_ftdi.c
+++ b/src/usb/ftdi/uhi_ftdi.c
@@ -262,7 +262,7 @@ static void ctl_req_end(
 }
 
 // read eeprom
-void ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial) {
+uint8_t ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial) {
 
   // get manufacturer string
   ctlReadBusy = 1;
@@ -288,7 +288,7 @@ void ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial) {
 
        )) {
     // print_dbg("\r\n control request for string descriptor failed");
-    return;
+    return 0;
   }
   // wait for transfer end
   while(ctlReadBusy) { ;; }
@@ -316,7 +316,7 @@ void ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial) {
 
        )) {
     // print_dbg("\r\n control request for string descriptor failed");
-    return;
+    return 0;
   }
   // wait for transfer end
   while(ctlReadBusy) { ;; }
@@ -342,7 +342,7 @@ void ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial) {
 
        )) {
     // print_dbg("\r\n control request for string descriptor failed");
-    return;
+    return 0;
   }
   // wait for transfer end
   while(ctlReadBusy) { ;; }
@@ -352,6 +352,7 @@ void ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial) {
   *pProduct = product_string + FTDI_STRING_DESC_OFFSET;
   *pSerial = serial_string + FTDI_STRING_DESC_OFFSET;
 
+  return 1;
 }
 
     /* for (i = 0; i < FTDI_EEPROM_SIZE__2; i++) { */

--- a/src/usb/ftdi/uhi_ftdi.h
+++ b/src/usb/ftdi/uhi_ftdi.h
@@ -38,6 +38,6 @@ extern bool uhi_ftdi_out_run(uint8_t * buf, iram_size_t buf_size,
 		uhd_callback_trans_t callback);
 
 // get string descriptions
-extern void ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial);
+extern uint8_t ftdi_get_strings(char** pManufacturer, char** pProduct, char** pSerial);
 
 #endif // _UHI_FTDI_H_


### PR DESCRIPTION
protecting `ftdi_setup` in case `ftdi_get_strings` doesn't execute successfully. also setting some reasonable defaults for `rows` and `cols` which would help with any code that uses `monome_size_x` / `monome_size_y` before a grid is detected.

@tehn @catfact please take a look.