### PR TITLE
single-packet midi_send, receive midi program_change messages

### DIFF
--- a/src/midi_common.c
+++ b/src/midi_common.c
@@ -69,6 +69,10 @@ void midi_packet_parse(midi_behavior_t *b, u32 data) {
 			break;
 		}
 		break;
+		case 0xc:
+			num = (data & 0x00ff0000) >> 16;
+			if (b->program_change) b->program_change(ch, num);
+			break;
 	default:
 		// TODO: poly pressure, program change, chanel mode *, rtc, etc
 		break;

--- a/src/midi_common.h
+++ b/src/midi_common.h
@@ -19,6 +19,7 @@ typedef void (*midi_note_off_t)(u8 ch, u8 num, u8 vel);
 typedef void (*midi_channel_pressure_t)(u8 ch, u8 val);
 typedef void (*midi_pitch_bend_t)(u8 ch, u16 bend);
 typedef void (*midi_control_change_t)(u8 ch, u8 num, u8 val);
+typedef void (*midi_program_change_t)(u8 ch, u8 num);
 typedef void (*midi_real_time_t)(void);
 typedef void (*midi_panic_t)(void);
 
@@ -28,6 +29,7 @@ typedef struct {
 	midi_channel_pressure_t channel_pressure;
 	midi_pitch_bend_t       pitch_bend;
 	midi_control_change_t   control_change;
+	midi_program_change_t   program_change;
 
 	midi_real_time_t        clock_tick;
 	midi_real_time_t        seq_start;

--- a/src/usb/midi/midi.c
+++ b/src/usb/midi/midi.c
@@ -223,6 +223,19 @@ extern bool midi_write(const u8* data, u32 bytes) {
 
   return true;
 }
+extern void midi_write_packet(u8 cable_number, u8 *pack) {
+  uint8_t txBuf[4] = {
+    pack[0] >> 4,
+    pack[0],
+    pack[1],
+    pack[2]
+  };
+  txBuf[0] |= (cable_number << 4) & 0xf0;
+  txBusy = true;
+  if (!uhi_midi_out_run((uint8_t*)txBuf, 4, &midi_tx_done)) {
+    print_dbg("\r\n midi tx endpoint error");
+  }
+}
 
 // MIDI device was plugged or unplugged
 extern void midi_change(uhc_device_t* dev, u8 plug) {

--- a/src/usb/midi/midi.c
+++ b/src/usb/midi/midi.c
@@ -42,6 +42,7 @@ typedef union {
 //------ static variables
 // 
 
+static bool midi_connected = false;
 // buffers must be word aligned per docs on uhd_ep_run()
 COMPILER_WORD_ALIGNED static usb_midi_event_t rxBuf[MIDI_RX_EVENT_BUF_SIZE];
 static volatile bool rxBusy = false;
@@ -111,9 +112,12 @@ static void midi_tx_done(usb_add_t add,
 
 // read and spawn events (non-blocking)
 extern void midi_read(void) {
+  if(!midi_connected) {
+    return;
+  }
   if (rxBusy == false) {
-    rxBytes = 0;
     rxBusy = true;
+    rxBytes = 0;
     if (!uhi_midi_in_run((u8*)rxBuf, sizeof rxBuf, &midi_rx_done)) {
       // hm, every uhd enpoint run always returns error...
       // ...because most of the time a rx job is already running, by only
@@ -224,6 +228,9 @@ extern bool midi_write(const u8* data, u32 bytes) {
   return true;
 }
 extern void midi_write_packet(u8 cable_number, u8 *pack) {
+  if(!midi_connected) {
+    return;
+  }
   uint8_t txBuf[4] = {
     pack[0] >> 4,
     pack[0],
@@ -231,6 +238,13 @@ extern void midi_write_packet(u8 cable_number, u8 *pack) {
     pack[2]
   };
   txBuf[0] |= (cable_number << 4) & 0xf0;
+  while (txBusy) {
+    if(!midi_connected) {
+      txBusy = false;
+      return;
+    }
+  }
+
   txBusy = true;
   if (!uhi_midi_out_run((uint8_t*)txBuf, 4, &midi_tx_done)) {
     print_dbg("\r\n midi tx endpoint error");
@@ -242,8 +256,12 @@ extern void midi_change(uhc_device_t* dev, u8 plug) {
   event_t e;
 
   if (plug) { 
-    e.type = kEventMidiConnect; 
+    midi_connected = true;
+    rxBusy = false;
+    txBusy = false;
+    e.type = kEventMidiConnect;
   } else {
+    midi_connected = false;
     e.type = kEventMidiDisconnect;
   }
 

--- a/src/usb/midi/midi.h
+++ b/src/usb/midi/midi.h
@@ -12,6 +12,7 @@ extern void midi_read(void);
 
 // write to MIDI device
 extern bool midi_write(const u8* data, u32 bytes);
+extern void midi_write_packet(u8 cable_number, u8 *pack);
 
 // MIDI device was plugged or unplugged
 extern void midi_change(uhc_device_t* dev, u8 plug);


### PR DESCRIPTION
I added the dumbest possible single-packet midi output function to libavr32 & it seems to work fine for implementing all the midi output features I wanted in BEES (note, cc, clock).

Also added program change messages to the libavr32 midi input parser.