### PR TITLE
fixed random.c bug

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -18,7 +18,7 @@ void random_seed(random_state_t *r, u32 seed) {
 }	
 	
 s16 random_next(random_state_t *r) {
-	r->x = r->x * r->c + r->a;
+	r->x = r->x * r->a + r->c;
   r->val = r->x;
   if (r->val < 0) {
     r->val *= -1;


### PR DESCRIPTION
fixed a bug for `random_state_t` where the multiplication and add constant values were switched. 

also there was a concern about how `random_next` is calculating the range for min/max that might necessitate a fix. as per my discussion with @catfact 

with min=0, max=7fff, when you run that line, you get this:
```
val = val % (x7fff + 1)
val = val % (0x8000)
val = val % (-1)
```

could be fixed if the calculated range(max-min + 1) is upcast from 16 to 32 bit I think?