### PR TITLE
update libavr32 random number generator

### DIFF
--- a/src/arp.c
+++ b/src/arp.c
@@ -303,9 +303,9 @@ static void arp_seq_build_random(arp_seq_t *s, chord_t *c) {
 	u8 count, upper, i;
 
 	count = c->note_count;
-	upper = (count > 0) ? count - 1 : 0;
+	upper = (count > 0) ? count : 0;
 
-	random_init(&r, time_now(), 0, upper);
+	random_seed(&r, time_now());
 
 	// ensure empty starts in a known state
 	for (i = 0; i < count; i++) {
@@ -315,7 +315,7 @@ static void arp_seq_build_random(arp_seq_t *s, chord_t *c) {
 	// go through each note, pick a random index within the sequence,
 	// place note at next free index...
 	for (i = 0; i < count; i++) {
-		ri = random_next(&r);
+		ri = random_next(&r) % upper;
 		while (!s->notes[ri].empty) {
 			ri++;
 			if (ri == count) ri = 0;

--- a/src/random.c
+++ b/src/random.c
@@ -1,12 +1,5 @@
 #include "random.h"
 
-void random_init(random_state_t *r, u32 seed, s16 min, s16 max) {
-	r->min = min;
-	r->max = max;
-
-	random_seed(r, seed);
-}
-
 void random_seed(random_state_t *r, u32 seed) {
     r->z = 12345;
     r->w = seed;
@@ -17,12 +10,9 @@ void random_seed(random_state_t *r, u32 seed) {
  * with-carry generators, x(n)=36969x(n-1)+carry,
  * y(n)=18000y(n-1)+carry mod 2^16, has period about 2^60
  */
-s16 random_next(random_state_t *r) {
+u32 random_next(random_state_t *r) {
     r->z = 36969 * (r->z & 65535) + (r->z >> 16);
     r->w = 18000 * (r->w & 65535) + (r->w >> 16);
-    u32 val = ((r->z << 16) + r->w) & 0x7FFFFFFF;
-
-	val = (val % ((r->max - r->min) + 1)) + r->min;
-	return val;
+    return ((r->z << 16) + r->w) & 0x7FFFFFFF;
 }
 

--- a/src/random.c
+++ b/src/random.c
@@ -1,7 +1,5 @@
 #include "random.h"
 
-// cribbed from aleph/bees op_random
-
 void random_init(random_state_t *r, u32 seed, s16 min, s16 max) {
 	r->min = min;
 	r->max = max;
@@ -10,20 +8,21 @@ void random_init(random_state_t *r, u32 seed, s16 min, s16 max) {
 }
 
 void random_seed(random_state_t *r, u32 seed) {
-	r->val = 0;
-	
-	r->a = 0x19660d;
-	r->c = 0x3c6ef35f;
-	r->x = seed;
+    r->z = 12345;
+    r->w = seed;
 }	
-	
+
+/*
+ * MWC generator concatenates two 16-bit multiply-
+ * with-carry generators, x(n)=36969x(n-1)+carry,
+ * y(n)=18000y(n-1)+carry mod 2^16, has period about 2^60
+ */
 s16 random_next(random_state_t *r) {
-	r->x = r->x * r->a + r->c;
-  r->val = r->x;
-  if (r->val < 0) {
-    r->val *= -1;
-	}
-  r->val = (r->val % ((r->max - r->min) + 1)) + r->min;
-	return r->val;
+    r->z = 36969 * (r->z & 65535) + (r->z >> 16);
+    r->w = 18000 * (r->w & 65535) + (r->w >> 16);
+    u32 val = ((r->z << 16) + r->w) & 0x7FFFFFFF;
+
+	val = (val % ((r->max - r->min) + 1)) + r->min;
+	return val;
 }
 

--- a/src/random.h
+++ b/src/random.h
@@ -7,8 +7,8 @@
 //----- types
 
 typedef struct {
-	s16 min, max, val;
-	u32 a, c, x;
+	s16 min, max;
+	u32 z, w;
 } random_state_t;
 
 //------------------------------

--- a/src/random.h
+++ b/src/random.h
@@ -7,17 +7,14 @@
 //----- types
 
 typedef struct {
-	s16 min, max;
 	u32 z, w;
 } random_state_t;
 
 //------------------------------
 //----- functions
 
-// initialize random generator
-extern void random_init(random_state_t *r, u32 seed, s16 min, s16 max);
 // (re)seed generator, restarting sequence
 extern void random_seed(random_state_t *r, u32 seed);
-extern s16 random_next(random_state_t *r);
+extern u32 random_next(random_state_t *r);
 
 #endif // header guard

--- a/test/unit/test_arp.c
+++ b/test/unit/test_arp.c
@@ -22,6 +22,9 @@
 // -- reset goes to beginning
 // -- loop loops
 // -- loop loops once per octave, note values increase by octave
+//
+u8 irqs_pause(void) { return 0; }
+void irqs_resume(u8 irq_flags) {}
 
 chord_t c;
 

--- a/test/unit/test_random.c
+++ b/test/unit/test_random.c
@@ -18,13 +18,14 @@ void test_random_init_and_seed(void) {
 	u16 i;
 	random_state_t r;
 
-	random_init(&r, GOOD_SEED, -1000, 1000);
+	//random_init(&r, GOOD_SEED, -1000, 1000);
+	random_seed(&r, GOOD_SEED);
 
-	TEST_ASSERT_EQUAL_INT(-1000, r.min);
-	TEST_ASSERT_EQUAL_INT(1000, r.max);
-	TEST_ASSERT_EQUAL_INT(GOOD_SEED, r.x);
+	//TEST_ASSERT_EQUAL_INT(-1000, r.min);
+	//TEST_ASSERT_EQUAL_INT(1000, r.max);
+	TEST_ASSERT_EQUAL_INT(GOOD_SEED, r.w);
 
-	s16 values[VALUE_COUNT];
+	u32 values[VALUE_COUNT];
 
 	for (i = 0; i < VALUE_COUNT; i++) {
 		values[i] = random_next(&r);
@@ -32,7 +33,7 @@ void test_random_init_and_seed(void) {
 
 	random_seed(&r, GOOD_SEED);
 
-	TEST_ASSERT_EQUAL_INT(GOOD_SEED, r.x);
+	TEST_ASSERT_EQUAL_INT(GOOD_SEED, r.w);
 
 	// re-seeding should produce the same sequence
 	for (i = 0; i < VALUE_COUNT; i++) {
@@ -41,7 +42,8 @@ void test_random_init_and_seed(void) {
 
 	// different seeds should produce sequences
 	int differences = 0;
-	random_init(&r, BAD_SEED, -1000, 1000);
+	//random_init(&r, BAD_SEED, -1000, 1000);
+	random_seed(&r, BAD_SEED);
 	for (i = 0; i < VALUE_COUNT; i++) {
 		if (values[i] != random_next(&r)) {
 			differences++;
@@ -50,6 +52,7 @@ void test_random_init_and_seed(void) {
 	TEST_ASSERT_TRUE(differences > VALUE_COUNT / 2);
 }
 
+/*
 void test_random_range(void) {
 	u32 i;
 	s32 v;
@@ -118,13 +121,13 @@ void test_random_range(void) {
 	TEST_ASSERT_TRUE_MESSAGE(got_min, "didn't hit -100");
 	TEST_ASSERT_TRUE_MESSAGE(got_min, "didn't hit -80");
 }
-
+*/
 
 int main(void) {
 	UNITY_BEGIN();
 
 	RUN_TEST(test_random_init_and_seed);
-	RUN_TEST(test_random_range);
+	//RUN_TEST(test_random_range);
 
 	return UNITY_END();
 }


### PR DESCRIPTION
this pull request is to update the algorithm used by the `random.c/h`. this is needed for the seed ops pull request for teletype.
https://github.com/monome/teletype/pull/176

basically the old algorithm was using a linear congruential generator which resulted in the lower bits to not be very random.  new algorithm is a multiply with carry prng.  I also removed the min/max range mod from the `random_next` function as the teletype op firmware already handles range limiting.

I did a search to see if any other firmware was using this generator.  as far as I could tell only `arp.c` (used by ansible) uses it.  a very slight modification to `arp.c` was needed since I removed the range modulus from the algorithm. I tried to update the unit tests in `libavr32/test/unit`, but received the following make error both before and after modification. maybe @ngwese can help with this, and hopefully also give input on these changes.

```
alphacactus:test ryanhodgman$ make
LN      > build/unit/test_arp.out
Undefined symbols for architecture x86_64:
  "_irqs_pause", referenced from:
      _arp_seq_set_state in test_arp.o
  "_irqs_resume", referenced from:
      _arp_seq_set_state in test_arp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [build/unit/test_arp.out] Error 1
```