### PR TITLE
ii messages for new ansible remote ops

### DIFF
--- a/src/ii.h
+++ b/src/ii.h
@@ -124,6 +124,7 @@
 #define II_ANSIBLE_CV_OFF   8
 #define II_ANSIBLE_CV_SET   9
 #define II_ANSIBLE_INPUT    10
+#define II_ANSIBLE_APP      15
 
 #define II_MID_SLEW     1
 #define II_MID_SHIFT    2
@@ -158,6 +159,9 @@
 #define II_KR_MUTE      9
 #define II_KR_TMUTE     10
 #define II_KR_CLK       11
+#define II_KR_PAGE      12
+#define II_KR_CUE       13
+#define II_KR_DIR       14
 
 #define II_MP_PRESET    0
 #define II_MP_RESET     1

--- a/src/ii.h
+++ b/src/ii.h
@@ -144,6 +144,7 @@
 #define II_GRID_KEY     16
 #define II_GRID_LED     17
 #define II_ARC_ENC      24
+#define II_ARC_LED      25
 
 #define II_KR_PRESET    0
 #define II_KR_PATTERN   1

--- a/src/ii.h
+++ b/src/ii.h
@@ -184,6 +184,7 @@
 #define II_CY_REV       3
 #define II_CY_CV        4
 
+
 #define JF_TR       1
 #define JF_RMODE    2
 #define JF_RUN      3

--- a/src/ii.h
+++ b/src/ii.h
@@ -141,6 +141,10 @@
 #define II_ARP_FILL     10
 #define II_ARP_ER       11
 
+#define II_GRID_KEY     16
+#define II_GRID_LED     17
+#define II_ARC_ENC      24
+
 #define II_KR_PRESET    0
 #define II_KR_PATTERN   1
 #define II_KR_SCALE     2


### PR DESCRIPTION
Adds ii message types for supporting the following Teletype remote ops for Ansible (discussion starts [here](https://llllllll.co/t/teletype-3-feature-requests-and-discussion/16219/291)). Binaries with these ops working are [here](https://llllllll.co/t/ansible-earthsea/6891/507). Will follow up with Teletype and Ansible merges after this is merged so I can fix up the submodule references.

```
ANS.G x y / ANS.G x y z   # get/set grid key state (z) at pos x, y
ANS.G.P x y               # simulate grid key press (down + up) on ansible at pos x, y
ANS.G.LED x y             # get grid LED state for key x, y
ANS.A n d                 # simulate arc encoder rotation of ring n, delta d
ANS.A.LED n x             # get arc LED state for ring n, LED x (clockwise from north)
KR.PG / KR.PG x           # get/set active kria page
KR.CUE / KR.CUE x         # get/set cued pattern
KR.DIR n / KR.DIR n x     # get/set step direction for track n to direction 0-4
```