### PR TITLE
add KR_DURATION ii message for reading kria step duration

### DIFF
--- a/src/ii.h
+++ b/src/ii.h
@@ -166,6 +166,7 @@
 #define II_KR_PAGE      12
 #define II_KR_CUE       13
 #define II_KR_DIR       14
+#define II_KR_DURATION  15
 
 #define II_MP_PRESET    0
 #define II_MP_RESET     1


### PR DESCRIPTION
Being able to read the current duration step for a Kria channel is pretty useful for e.g. mapping it to Just Friends velocity, or for otherwise using this parameter in scripts. Some discussion starting [here](https://llllllll.co/t/ansible-development-and-beta-firmware-discussion/23118/234). I will follow up with PRs for Ansible, Teletype, and crow.