### PR TITLE
change terminology in public i2c API

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -19,7 +19,7 @@ static twi_package_t packet;
 volatile process_ii_t process_ii;
 
 
-int i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t length) {
+int i2c_leader_tx(uint8_t addr, uint8_t *data, uint8_t length) {
   int status;
 
   packet.chip = addr;
@@ -36,7 +36,7 @@ int i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t length) {
 }
 
 
-int i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l) {
+int i2c_leader_rx(uint8_t addr, uint8_t *data, uint8_t l) {
   int status;
 
   packet.chip = addr;
@@ -53,7 +53,7 @@ int i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l) {
 
 
 
-void twi_slave_rx(uint8_t u8_value)
+void twi_follower_rx(uint8_t u8_value)
 {
   if (rx_pos[rx_buffer_index] < I2C_RX_BUF_SIZE) {
     rx_buffer[rx_buffer_index][rx_pos[rx_buffer_index]] = u8_value;
@@ -61,12 +61,12 @@ void twi_slave_rx(uint8_t u8_value)
   }
 }
 
-void twi_slave_stop(void)
+void twi_follower_stop(void)
 {
   uint8_t index = rx_buffer_index;
   // rx_buffer_index must be incremented before process_ii is called
   if (++rx_buffer_index >= RX_BUFFER_COUNT) rx_buffer_index = 0;
-  
+
   process_ii(rx_buffer[index], rx_pos[index]);
   rx_pos[index] = 0;
 }
@@ -84,7 +84,7 @@ extern void ii_tx_queue(uint8_t data) {
     print_dbg("\r\nii queue overrun");
 }
 
-uint8_t twi_slave_tx(void)
+uint8_t twi_follower_tx(void)
 {
    // print_dbg("\r\nii_tx ");
    if(tx_pos_write == tx_pos_read)

--- a/src/i2c.h
+++ b/src/i2c.h
@@ -11,12 +11,12 @@
 #define I2C_TX_BUF_SIZE 8
 #define I2C_RX_BUF_SIZE 8
 
-extern int i2c_master_tx(uint8_t addr, uint8_t *data, uint8_t l);
-extern int i2c_master_rx(uint8_t addr, uint8_t *data, uint8_t l);
+extern int i2c_leader_tx(uint8_t addr, uint8_t *data, uint8_t l);
+extern int i2c_leader_rx(uint8_t addr, uint8_t *data, uint8_t l);
 
-extern void twi_slave_rx(uint8_t u8_value);
-extern uint8_t twi_slave_tx(void);
-extern void twi_slave_stop(void);
+extern void twi_follower_rx(uint8_t u8_value);
+extern uint8_t twi_follower_tx(void);
+extern void twi_follower_stop(void);
 
 extern void ii_tx_queue(uint8_t);
 

--- a/src/init_common.c
+++ b/src/init_common.c
@@ -68,7 +68,7 @@ void init_usb_host (void) {
 }
 
 // initialize i2c
-void init_i2c_master(void) {
+void init_i2c_leader(void) {
   twi_options_t opt;
 
   int status;
@@ -96,7 +96,7 @@ void init_i2c_master(void) {
   //   print_dbg("\r\ni2c init FAIL");
 }
 
-void init_i2c_slave(uint8_t addr) {
+void init_i2c_follower(uint8_t addr) {
   static const gpio_map_t TWI_GPIO_MAP =
   {
     {AVR32_TWI_SDA_0_0_PIN, AVR32_TWI_SDA_0_0_FUNCTION},
@@ -115,19 +115,19 @@ void init_i2c_slave(uint8_t addr) {
   opt.chip = addr;
 
   // initialize TWI driver with options
-  twi_slave_fct.rx = &twi_slave_rx;
-  twi_slave_fct.tx = &twi_slave_tx;
-  twi_slave_fct.stop = &twi_slave_stop;
+  twi_slave_fct.rx = &twi_follower_rx;
+  twi_slave_fct.tx = &twi_follower_tx;
+  twi_slave_fct.stop = &twi_follower_stop;
   status = twi_slave_init(&AVR32_TWI, &opt, &twi_slave_fct );
 /*  // check init result
   if (status == TWI_SUCCESS)
   {
     // display test result to user
-    print_dbg("Slave start:\tPASS\r\n");
+    print_dbg("follower start:\tPASS\r\n");
   }
   else
   {
     // display test result to user
-    print_dbg("slave start:\tFAIL\r\n");
+    print_dbg("follower start:\tFAIL\r\n");
   }*/
 }

--- a/src/init_common.h
+++ b/src/init_common.h
@@ -5,7 +5,7 @@
 
 extern void init_tc(void);
 extern void init_usb_host (void);
-extern void init_i2c_master(void);
-extern void init_i2c_slave(uint8_t addr);
+extern void init_i2c_leader(void);
+extern void init_i2c_follower(uint8_t addr);
 
 #endif


### PR DESCRIPTION
There are a bunch of others in internal ASF libraries but I think this is everything that gets used in downstream code bases.