### PR TITLE
remove delay causing timing glitches on FTDI connect

### DIFF
--- a/src/usb/ftdi/uhi_ftdi.c
+++ b/src/usb/ftdi/uhi_ftdi.c
@@ -191,8 +191,6 @@ void uhi_ftdi_enable(uhc_device_t* dev) {
 		   0, 49206,
 		   NULL);
 
-  delay_ms(200);
-
   ftdi_change(dev, true);
 }
 


### PR DESCRIPTION
@scanner-darkly [identified](https://github.com/monome/ansible/issues/23#issuecomment-611139290) this change as a fix for the timing glitches seen when connecting grid or arc to ansible -- this change should allow fixing https://github.com/monome/ansible/issues/23. Users have tried the patch with several devices without seeing issues, including

- current edition grids
- walnut varibright grids
- grayscale grids
- current edition arc