### PR TITLE
add ii address for crow follower mode

### DIFF
--- a/src/ii.h
+++ b/src/ii.h
@@ -2,6 +2,8 @@
 // each device must use a unique address (0x01-0x7F)
 // 0 is RESERVED for global commands
 
+#define CROW                0x01
+
 #define WW                  0x10
 #define WW_KRIA             0x10 // ww kria uses ww address
 

--- a/src/ii.h
+++ b/src/ii.h
@@ -214,6 +214,15 @@
 #define JF_GOD      10
 #define JF_TUNE     11
 #define JF_QT       12
+#define JF_PITCH    13
+#define JF_ADDRESS  14
+#define JF_SPEED    15
+#define JF_TSC      16
+#define JF_RAMP     17
+#define JF_CURVE    18
+#define JF_FM       19
+#define JF_TIME     20
+#define JF_INTONE   21
 
 #define WS_REC  1
 #define WS_PLAY 2


### PR DESCRIPTION
The [spec-like things](https://www.nxp.com/docs/en/user-guide/UM10204.pdf#G1656361) for I2C I've found online indicate that 0x01 is a reserved address for the defunct CBUS and " I2C-bus compatible devices are not allowed to respond on reception of this address" but I don't know / doubt if we should care.