### PR TITLE
Check for NVRAM overflow

### DIFF
--- a/src/link_uc3b0512.lds
+++ b/src/link_uc3b0512.lds
@@ -278,6 +278,8 @@ SECTIONS
   {
     *(.flash_nvram)
   } >FLASH AT>FLASH :FLASH_NVRAM
+  /* Ensure nvdata storage hasn't been relocated due to program size overflow */
+  ASSERT(ADDR(.flash_nvram) >= (LOADADDR(.data) + SIZEOF(.data)), ".data overflowed into .nvram!")
   .userpage       : { *(.userpage .userpage.*) } >USERPAGE AT>USERPAGE :USERPAGE
   /DISCARD/ : { *(.note.GNU-stack) }
 }


### PR DESCRIPTION
This PR adds a simple assertion to ensure that the `.data` section doesn't overflow past the nominal `.flash_nvram` location. I'm sure there's a way to make this requirement explicit in the standard linker script form, but I simply don't know how, and this works. 

Tested to ensure it catches the bug the Teletype dev crew had been experiencing.