### PR TITLE
keyboard fix

### DIFF
--- a/src/usb/hid/hid.c
+++ b/src/usb/hid/hid.c
@@ -38,17 +38,19 @@ static u8 size = HID_FRAME_MAX_BYTES;
 
 // set/unset dirty flag for given byte in frame
 static inline void hid_set_byte_flag(u8 byte, u8 val) {
-  if(val) {
-    dirty |= (1 << byte);
-  } else {
-    dirty &= ~(1 << byte);
+  if (byte<64) { //bytecount guard
+    if(val) {
+      dirty |= (1ULL << byte); //needs to be ULL. "1" is compiled as u32 int, so shifting > 32 is undefined
+    } else {
+      dirty &= ~(1ULL << byte);
+    }
   }
 }
 
 // test dirty flag for given byte in packet
 //u8 hid_get_byte_flag(u32 data, u8 byte) {
 u8 hid_get_byte_flag(u8 byte) {
-  return (dirty & (1 << byte)) > 0;
+  return (dirty & (1ULL << byte)) > 0;
 }
 
 // parse frame and spawn events

--- a/src/usb/hid/hid.c
+++ b/src/usb/hid/hid.c
@@ -30,7 +30,7 @@ static u8 frame[HID_FRAME_MAX_BYTES] = {
   0x00,   0x00,   0x00,   0x00, 
 };
 
-static u32 dirty = 0xffffffff;
+static u64 dirty = 0xffffffffffffffff;
 static u8 size = HID_FRAME_MAX_BYTES;
 
 // app polls
@@ -41,7 +41,7 @@ static inline void hid_set_byte_flag(u8 byte, u8 val) {
   if(val) {
     dirty |= (1 << byte);
   } else {
-    dirty &= 0xffffffff ^ (1 << byte);
+    dirty &= ~(1 << byte);
   }
 }
 
@@ -88,8 +88,8 @@ const volatile u8 hid_get_frame_size(void) {
   return (const volatile u8)size;
 }
 
-const volatile u32 hid_get_frame_dirty(void) {
-  return (const volatile u32)dirty;
+const volatile u64 hid_get_frame_dirty(void) {
+  return (const volatile u64)dirty;
 }
 
 // HID device was plugged or unplugged
@@ -107,7 +107,7 @@ extern void hid_change(uhc_device_t* dev, u8 plug) {
 
 // clear the bitfield of dirty bytes
 extern void hid_clear_frame_dirty(void) {
-  dirty = 0x00000000;
+  dirty = 0x0000000000000000;
 }
 
 #include "uhc.h"

--- a/src/usb/hid/hid.h
+++ b/src/usb/hid/hid.h
@@ -25,7 +25,7 @@ extern void hid_parse_frame(u8* frame, u8 size);
 extern const volatile u8* hid_get_frame_data(void);
 
 // get the bitfield of dirty bytes
-extern const volatile u32 hid_get_frame_dirty(void);
+extern const volatile u64 hid_get_frame_dirty(void);
 
 // clear the bitfield of dirty bytes
 extern void hid_clear_frame_dirty(void);


### PR DESCRIPTION
a considerable portion of usb keyboards would not work properly with teletype; registering the first keypress, then not registering the keyup packet, or any subsequent packets.

there were a couple of issues with the dirty flag in the HID processing and callback functions; now, all full speed (64byte report size) keyboards should work (internal USB hubs aside). 

a large portion of keyboards that would previously not work with teletype should now be functional! this should mostly apply to enthusiast and 3rd party but not open-source keebs as well!